### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,11 @@ module.exports = {
   organizationName: 'grid-js',
   projectName: 'website',
   themeConfig: {
+    algolia: {
+    apiKey: '15086b8795378f5116d77008d1c3ebf0',
+    indexName: 'gridjs',
+    algoliaOptions: {} // Optional, if provided by Algolia
+    },
     googleAnalytics: {
       trackingID: 'UA-167499954-1',
     },


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.