### PR TITLE
Missing enabled parameter

### DIFF
--- a/docs/examples/server-side-pagination.md
+++ b/docs/examples/server-side-pagination.md
@@ -21,6 +21,7 @@ is correctly defined in the main `server` config block:
 const grid = new Grid({
   columns: ['Pokemon', 'URL'],
   pagination: {
+    enabled: true,
     limit: 5,
     server: {
       url: (prev, page, limit) => \`\${prev}?limit=\${limit}&offset=\${page * limit}\`


### PR DESCRIPTION
Without the enabled parameter setup in the pagination property, I'm getting the following error:

```
TS2322: Type '{ limit: number; server: { url: (prev: string, page: number, limit: number) => string; }; }' is not assignable to type 'boolean | PaginationConfig'.
  Property 'enabled' is missing in type '{ limit: number; server: { url: (prev: string, page: number, limit: number) => string; }; }' but required in type 'PaginationConfig'.
```