### PR TITLE
Corrected response handling in example code

### DIFF
--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -21,7 +21,7 @@ const grid = new Grid({
   columns: ['Name', 'Language', 'Released At', 'Artist'],
   server: {
     url: 'https://api.scryfall.com/cards/search?q=Inspiring',
-    then: data => data.map(card => [card.name, card.lang, card.released_at, card.artist])
+    then: response => response.data.map(card => [card.name, card.lang, card.released_at, card.artist])
   } 
 });
 `


### PR DESCRIPTION
Was looking through the docs and noticed that the example for calling an API endpoint was showing an error:

![image](https://user-images.githubusercontent.com/28209769/132587290-57e754b7-ef55-40e5-b463-f2b42a436648.png)

The API endpoint being used returns an object, but the `then` handler is expecting an array. I changed the parameter on that handler to represent the response from the API, and then access the expected list on the `data` property. 

I did not test this locally, but this change to the example code works when I tested it in the editor:

![image](https://user-images.githubusercontent.com/28209769/132587404-f5159ec3-e681-4403-94ef-3e4fc7d09a19.png)
