### PR TITLE
[DOC] Fix module name in import

### DIFF
--- a/docs/integrations/angular.md
+++ b/docs/integrations/angular.md
@@ -14,10 +14,10 @@ npm install gridjs gridjs-angular
 In your module
 
 ```ts
-import { GridjsAngularModule } from 'gridjs-angular';
+import { GridJsAngularModule } from 'gridjs-angular';
 
 @NgModule({
-  imports: [CommonModule,GridjsAngularModule],
+  imports: [CommonModule,GridJsAngularModule],
   declarations: [...],
   exports: [...],
 })


### PR DESCRIPTION
Hi there,
there seems to be a capitalization error in the docs.
The import as stated in the docs (`GridjsAngularModule`) did not work for me. However there is a module with the name `GridJsAngularModule`.

Cheers