### PR TITLE
hidden-columns.md: update note

### DIFF
--- a/docs/examples/hidden-columns.md
+++ b/docs/examples/hidden-columns.md
@@ -39,5 +39,12 @@ const grid = new Grid({
 <br/>
 
 :::note
-Enabling the `hidden` flag only affects the rendering process of your Grid.js instance. Hidden columns are still searchable. 
+Hidden columns will be ignored by the [search plugin](./search.md) unless `ignoreHiddenColumns` is set to `false`.
+ 
+```
+  search: {
+    ignoreHiddenColumns: false,
+  },
+``` 
+
 :::


### PR DESCRIPTION
The note previously stated that hidden columns are searchable, but this isn't presently true, as the search plugin defaults `ignoreHiddenColumns` to `true`:
```
          ignoreHiddenColumns:
            props.ignoreHiddenColumns ||
            props.ignoreHiddenColumns === undefined,
```
-- https://github.com/grid-js/gridjs/blob/5e80997/src/view/plugin/search/search.tsx#L62-L64

You can confirm this using a live editor:

1. https://gridjs.io/docs/examples/search
2. Modify the first example to hide the `Name` column:

```
  columns: [
    { 
      name: 'Name',
      hidden: true
    },
    'Email',
    'Phone Number'
  ],
```

3. Try to search for "nisen", nothing will be found.
4. Make another modification to set `ignoreHiddenColumns` to `false`:

```
  search: {
    ignoreHiddenColumns: false,
  },
```

5. Try to search for "nisen", the last row will match.