### PR TITLE
FIX: typo in Description of enabled config

### DIFF
--- a/docs/config/sort.md
+++ b/docs/config/sort.md
@@ -69,7 +69,7 @@ new Grid({
 
 | Name                    | Description                         |  Type              |
 |-------------------------|-------------------------------------|--------------------|
-| enabled                 | to enable/disable pagination        | boolean            |
+| enabled                 | to enable/disable sorting           | boolean            |
 | compare `optional`      | custom comparator function          | `Comparator<TCell>`|
 
 </div>


### PR DESCRIPTION
correction of the 'enabled' description, "sorting" not "pagination".