### PR TITLE
fix: scryfall API response

### DIFF
--- a/docs/examples/server.md
+++ b/docs/examples/server.md
@@ -21,7 +21,7 @@ const grid = new Grid({
   columns: ['Name', 'Language', 'Released At', 'Artist'],
   server: {
     url: 'https://api.scryfall.com/cards/search?q=Inspiring',
-    then: data => data.map(card => [card.name, card.lang, card.released_at, card.artist])
+    then: data => data.data.map(card => [card.name, card.lang, card.released_at, card.artist])
   } 
 });
 `


### PR DESCRIPTION
The cards are actually located in `.data`. See other examples like https://github.com/grid-js/website/blob/44367d1c203337740a382189109fab7528a35638/docs/examples/server-side-sort.md